### PR TITLE
Fix megaphone loop type

### DIFF
--- a/CPP00/ex00/megaphone.cpp
+++ b/CPP00/ex00/megaphone.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cctype>
 
 int main(int argc, char const *argv[])
 {
@@ -12,8 +13,8 @@ int main(int argc, char const *argv[])
 		while (*argv)
 		{
 			str = *argv;
-			for (int i = 0; i < str.length(); i++)
-				str[i] = std::toupper(str[i]);
+                        for (std::size_t i = 0; i < str.length(); ++i)
+                                str[i] = std::toupper(static_cast<unsigned char>(str[i]));
 			std::cout << str;
 			argv++;
 		}


### PR DESCRIPTION
## Summary
- include `<cctype>` for `std::toupper`
- use `std::size_t` in the loop to avoid signed/unsigned warnings

## Testing
- `make -C CPP00/ex00`


------
https://chatgpt.com/codex/tasks/task_e_6841cbfbb4d48328b69faba4a4cffb4d