### PR TITLE
Fix timestamp call for C++98

### DIFF
--- a/CPP00/ex02/Account.cpp
+++ b/CPP00/ex02/Account.cpp
@@ -117,7 +117,7 @@ void Account::_displayTimestamp(void)
 {
 	char buffer[20];
 
-	std::time_t now = std::time(nullptr);
+       std::time_t now = std::time(NULL);
 	std::tm *tm_now = std::localtime(&now);
 	std::strftime(buffer, sizeof(buffer), "[%Y%m%d_%H%M%S] ", tm_now);
 	std::cout << buffer;


### PR DESCRIPTION
## Summary
- update `Account.cpp` to use `std::time(NULL)` rather than `nullptr`
- build `CPP00/ex02` with C++98 successfully

## Testing
- `make -C CPP00/ex02 clean`
- `make -C CPP00/ex02`

------
https://chatgpt.com/codex/tasks/task_e_6841cc1e140c832894601c6509fa84fc